### PR TITLE
build: Switch to .NET 7 SDK

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
   <!-- Compiler settings-->
   <PropertyGroup>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Disable warning CS1591 (missing XML documentation comments) -->

--- a/build.ps1
+++ b/build.ps1
@@ -1,8 +1,5 @@
 $ErrorActionPreference = "Stop"
 
-# Install .NET 5 runtime (requried for runnign some of the local tools during build)
-./build/dotnet-install.ps1 -Channel 5.0 -Runtime dotnet
-
 # Install SDK and runtime as specified in global.json
 ./build/dotnet-install.ps1 -JsonFile "$PSScriptRoot/global.json"
 

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <RunWorkingDirectory>$(MSBuildProjectDirectory)\..\</RunWorkingDirectory>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/build/packages.lock.json
+++ b/build/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net7.0": {
       "Cake.BuildSystems.Module": {
         "type": "Direct",
         "requested": "[4.2.0, )",

--- a/docs/api/Utilities.Logging/Grynwald/Utilities/Logging/SimpleConsoleLogger/methods/IsEnabled.md
+++ b/docs/api/Utilities.Logging/Grynwald/Utilities/Logging/SimpleConsoleLogger/methods/IsEnabled.md
@@ -21,7 +21,7 @@ public bool IsEnabled(LogLevel logLevel);
 
 `logLevel`  LogLevel
 
-level to be checked.
+Level to be checked.
 
 ## Returns
 

--- a/global.json
+++ b/global.json
@@ -3,6 +3,6 @@
    "MSBuild.Sdk.Extras": "3.0.44"
  },
   "sdk": {
-    "version": "6.0.404"
+    "version": "7.0.101"
   }
 }

--- a/src/Utilities.Configuration.Test/Grynwald.Utilities.Configuration.Test.csproj
+++ b/src/Utilities.Configuration.Test/Grynwald.Utilities.Configuration.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Utilities.Configuration.Test/packages.lock.json
+++ b/src/Utilities.Configuration.Test/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[3.2.0, )",

--- a/src/Utilities.Test/Grynwald.Utilities.Test.csproj
+++ b/src/Utilities.Test/Grynwald.Utilities.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Utilities.Test/packages.lock.json
+++ b/src/Utilities.Test/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net7.0": {
       "coverlet.collector": {
         "type": "Direct",
         "requested": "[3.2.0, )",


### PR DESCRIPTION
Use the .NET 7 SDK and enable usage of C# 11

Retarget test and build projects to .NET 7.
Continue to target .NET Standard 2.0 for the main libraries.